### PR TITLE
Manual use of next fixes crawling

### DIFF
--- a/planefinder/crawler.py
+++ b/planefinder/crawler.py
@@ -29,10 +29,14 @@ class Crawler:
         log.info(f"Crawling, starting from {self.entry}")
         listings_page = tap.ListingsPage(self.entry)
         page_counter = 0
-        for page in listings_page:
+        while True:
             page_counter += 1
             log.info(f"Reading entries, page {page_counter}")
-            for entry in page.entries:
+            for entry in listings_page.entries:
                 aircraft_sale_entry = AircraftSaleEntry.from_listings_entry(entry)
                 log.info(f"Saving aircraft entry {aircraft_sale_entry.id}")
                 self.database.save(aircraft_sale_entry)
+            try:
+                listings_page = next(listings_page)
+            except StopIteration:
+                break

--- a/planefinder/data.py
+++ b/planefinder/data.py
@@ -121,7 +121,7 @@ class Database:
     def save_or_update(self, object_):
         if isinstance(object_, AircraftSaleEntry):
             obj_dict = object_.__dict__
-            del obj_dict["_id"]
+            obj_dict.pop("_id", None)
             return self.conn["AircraftSaleEntry"].update_one(
                 {"id": object_.id}, {"$set": obj_dict}, upsert=True
             )

--- a/planefinder/trade_a_plane.py
+++ b/planefinder/trade_a_plane.py
@@ -39,9 +39,6 @@ class ListingsPage:
         for entry_soup in self.page_soup.find_all(is_listing_result):
             yield ListingEntry(self, entry_soup)
 
-    def __iter__(self):
-        return self
-
     def __next__(self):
         next_url_path = next_page_url(self.page_soup)
         if next_url_path == "":

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -1,0 +1,28 @@
+class MyIterable:
+    """
+    An iterator that returns an updated state of itself.
+    
+    In this case, it is a counter. In the `Planefinder` application,
+    the `ListingPage` class does this. It updates its URL and page
+    data.
+    """
+
+    def __init__(self):
+        self.x = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.x > 10:
+            raise StopIteration
+        self.x += 1
+        return self
+
+
+def test_my_iterable():
+    my_iter = MyIterable()
+    expected_x = 0
+    for state in my_iter:
+        assert expected_x == state.x - 1
+        expected_x += 1


### PR DESCRIPTION
ListingsPage may have a __next__ function but it is not an iterator.
Require calling next(listings_page) to get the next page.
The `for next_ in listings_page` iteration skips the first page.
I don't know how to make it more elegant so manual iteration seems best.